### PR TITLE
Fix documentation location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,9 +2,7 @@
 
 SUBDIRS = src sql webcontent i18n 
 
-opendiasdocdir = ${prefix}/doc/opendias
-opendiasdoc_DATA = ChangeLog
-EXTRA_DIST = $(opendiasdoc_DATA)
+dist_doc_DATA = ChangeLog README TODO
 
 install-exec-hook:
 	test ! -e ${VAR_DIR}/run && mkdir -p ${VAR_DIR}/run || echo Run directory already exists


### PR DESCRIPTION
/usr/doc is present in some distros as a symlink but /usr/share/doc is the LSB location. dist_doc_DATA is the proper way to install documentation.
