### PR TITLE
Evaluate Makefile wildcards in source tree

### DIFF
--- a/i18n/Makefile.am
+++ b/i18n/Makefile.am
@@ -2,7 +2,7 @@
 sql_SCRIPTS = 
 
 sql_DATA = \
-	language.resource.* 
+	$(srcdir)/language.resource.*
 
 sqldir = \
 	$(pkgdatadir)

--- a/webcontent/Makefile.am
+++ b/webcontent/Makefile.am
@@ -2,11 +2,11 @@
 SUBDIRS = style includes images
 
 web_DATA = \
-  accessControls.html.* \
-  docList.html.* \
-  docDetail.html.* \
-  body.html.* \
-  acquire.html.* 
+	$(srcdir)/accessControls.html.* \
+	$(srcdir)/docList.html.* \
+	$(srcdir)/docDetail.html.* \
+	$(srcdir)/body.html.* \
+	$(srcdir)/acquire.html.*
 
 webdir = \
 	$(pkgdatadir)/webcontent

--- a/webcontent/includes/Makefile.am
+++ b/webcontent/includes/Makefile.am
@@ -1,8 +1,8 @@
 SUBDIRS = local
 
 web_DATA = \
-  header.txt.* \
-  footer.txt.* \
+	$(srcdir)/header.txt.* \
+	$(srcdir)/footer.txt.* \
 	jquery.canvas-loader.js \
 	jquery.easySlider.js \
 	jquery.gzoom.js \
@@ -10,15 +10,15 @@ web_DATA = \
 	jquery.js \
 	jquery.mousewheel.js \
 	jquery-ui.min.js \
-  sprintf-0.7-beta1.js \
+	sprintf-0.7-beta1.js \
 	openDias.acquire.js \
 	openDias.docList.js \
 	openDias.filter.js \
 	openDias.loadDetails.js \
 	openDias.saveDetails.js \
 	openDias.accessControls.js \
-  openDias.accessMethods.js \
-  openDias.userdetails.js 
+	openDias.accessMethods.js \
+	openDias.userdetails.js
 
 webdir = \
 	$(pkgdatadir)/webcontent/includes

--- a/webcontent/includes/local/Makefile.am
+++ b/webcontent/includes/local/Makefile.am
@@ -1,12 +1,12 @@
 
 web_DATA = \
-  generic.resource.* \
-  openDias.acquire.js.resource.* \
-  openDias.loadDetails.js.resource.* \
-  openDias.saveDetails.js.resource.* \
-  openDias.docList.js.resource.* \
-  openDias.filter.js.resource.* \
-  openDias.accessControls.js.resource.*
+	$(srcdir)/generic.resource.* \
+	$(srcdir)/openDias.acquire.js.resource.* \
+	$(srcdir)/openDias.loadDetails.js.resource.* \
+	$(srcdir)/openDias.saveDetails.js.resource.* \
+	$(srcdir)/openDias.docList.js.resource.* \
+	$(srcdir)/openDias.filter.js.resource.* \
+	$(srcdir)/openDias.accessControls.js.resource.*
 
 webdir = \
 	$(pkgdatadir)/webcontent/includes/local


### PR DESCRIPTION
As discussed on the train, building from outside the source tree currently breaks because the wildcards are evaluated in the build tree. Please check that the result is correct here. I haven't actually fired up openDias yet!

P.S. Watch your whitespace. ;)
